### PR TITLE
Feat/project pages

### DIFF
--- a/app/api/getGithubData.ts
+++ b/app/api/getGithubData.ts
@@ -1,0 +1,109 @@
+type Project = {
+    title: string
+    description: string
+    href: string
+    stars?: number
+    organization?: string
+    forks?: number
+    watchers?: number
+}
+
+export const contributionsData: Project[] = [
+    {
+        title: 'calcom/cal.com',
+        description: '',
+        href: 'https://github.com/calcom/cal.com/pull/21065',
+    },
+    {
+        title: 'rangle/radius',
+        description: '',
+        organization: 'rangle',
+        href: 'https://github.com/rangle/radius/issues?q=is%3Aissue%20state%3Aclosed%20author%3Ausrrname',
+    },
+    {
+        title: 'rangle/radius-workspace',
+        description: '',
+        href: 'https://github.com/rangle/radius-workspace/pulls?q=is%3Apr+author%3Ausrrname+is%3Aclosed',
+    },
+    {
+        title: 'storybookjs/storybook',
+        description: '',
+        href: 'https://github.com/storybookjs/storybook/pulls?q=is%3Apr+is%3Aclosed+author%3Ausrrname',
+    },
+    {
+        title: 'cloudflare/cloudflare-docs',
+        description: '',
+        href: 'https://github.com/cloudflare/cloudflare-docs/issues/15718',
+    },
+    {
+        title: 'microsoft/fast',
+        description: '',
+        href: 'https://github.com/microsoft/fast/issues?q=is%3Aissue%20state%3Aclosed%20author%3Ausrrname',
+    }
+]
+
+export const ossData: Project[] = [
+    {
+      title: '@usrrname/cursorrules',
+      description: '',
+      href: 'https://github.com/usrrname/cursorrules',
+    },
+    {
+      title: '@curveball/a12n-server',
+      description: 'A lightweight OAuth2.0 compliant authentication server',
+      organization: 'curveball',
+      href: 'https://github.com/curveball/a12n-server',
+    },
+    {
+      title: '@curveball/next-a12n',
+      description: '',
+      organization: 'curveball',
+      href: 'https://github.com/curveball/next-a12n',
+    },
+    {
+      title: '@curveball/a12n-server-admin',
+      organization: 'curveball',
+      description: '',
+      href: 'https://github.com/curveball/a12n-server-admin',
+    }
+]
+
+export async function getGithubData(data: Project[]) {
+  // Filter only projects with a GitHub href
+  const githubProjects = data.filter((p) =>
+    p.href?.startsWith('https://github.com/')
+  )
+
+  // Map to fetch star counts
+  const results = await Promise.all(
+    githubProjects.map(async (project) => {
+      try {
+        // Extract owner/repo from URL
+        const match = project.href!.match(/github\.com\/([^/]+)\/([^/]+)/)
+        if (!match) return { ...project, stars: null }
+        const [, owner, repo] = match
+
+        // Fetch repo data from GitHub API
+        const res = await fetch(
+          `https://api.github.com/repos/${owner}/${repo}`,
+          {
+            headers: {
+              Accept: 'application/vnd.github.v3+json',
+              Authorization: `Bearer ${process.env.GITHUB_TOKEN}`,
+            },
+            next: { revalidate: 3600 }, // cache for 1 hour
+          }
+        )
+       
+        if (!res.ok) throw new Error('Failed to fetch')
+        const data = await res.json()
+        console.log(`data:`, data)
+        return { ...project, description: data.description, stars: data.stargazers_count, forks: data.forks_count, watchers: data.watchers_count }
+      } catch {
+        return { ...project, stars: null }
+      }
+    })
+  )
+
+  return [...results]
+}

--- a/app/projects/page.tsx
+++ b/app/projects/page.tsx
@@ -1,0 +1,78 @@
+import { contributionsData, getGithubData, ossData } from '@/app/api/getGithubData'
+import ForkIcon from '@/components/icons'
+import { genPageMetadata } from 'app/seo'
+import Link from 'next/link'
+
+export const metadata = genPageMetadata({ title: 'Projects' })
+
+export default async function Projects() {
+    const projectData = await getGithubData(ossData)
+    const contributions = await getGithubData(contributionsData)
+    return (
+        <>
+            <div className="divide-y divide-gray-200 dark:divide-gray-700">
+                <div className="space-y-2 pt-6 pb-8 md:space-y-5">
+                    <h1 className="font-headings text-3xl leading-9 font-extrabold tracking-tight text-gray-900 sm:text-4xl sm:leading-10 md:text-6xl md:leading-14 dark:text-gray-100">
+                        Open Source
+                    </h1>
+                    <p className="text-lg leading-7 text-gray-500 dark:text-gray-400">
+                        Projects I maintain or contributed to.
+                        <br />
+                    </p>
+                </div>
+                <div className="container py-12 px-4 flex flex-col gap-4 sm:flex-row">
+                    <div className="flex flex-col border-gray-200 dark:border-gray-700 pb-4 gap-4">
+                        <p className="text-lg leading-7 text-neutral-500 dark:text-gray-400">
+                            Maintaining
+                        </p>
+                        {projectData.map((d) => (
+                            <div key={d.title}>
+                                <Link href={d.href || ''} className="text-lg leading-7 text-gray-500 dark:text-gray-400 hover:text-gray-900 dark:hover:text-gray-100">
+                                    <p className="text-lg leading-7 text-blue-800 dark:text-gray-400 hover:text-gray-900 dark:hover:text-gray-100">
+                                        {d.title}
+                                    </p>
+                                </Link>
+                                <p className="text-sm leading-7 text-gray-600 dark:text-gray-400">
+                                    {d.description}
+                                </p>
+                                <div className="flex flex-row gap-2 items-center">
+
+                                    {d.stars > 0 && (
+                                        <span className="text-sm leading-7 text-gray-600 dark:text-gray-400">
+                                            {d.stars} ⭐️
+                                        </span>
+                                    )}
+
+                                    {d.forks > 0 && (
+                                        <span className="text-sm leading-7 text-gray-600 dark:text-gray-400">
+                                            {d.forks} <ForkIcon className="w-4 h-4 inline-block" />
+                                        </span>
+                                    )}
+                                    {d.watchers > 0 && (
+                                        <span className="text-sm leading-7 text-gray-600 dark:text-gray-400">
+                                            {d.watchers} 👀
+                                        </span>
+                                    )}
+                                </div>
+                            </div>
+                        ))}
+                    </div>
+                    <div className="flex flex-col gap-4 border-gray-200 dark:border-gray-700 pb-4">
+                        <p className="text-lg leading-7 text-neutral-500 dark:text-gray-400">
+                            Contributions
+                        </p>
+                        {contributions.map((d) => (
+                            <div key={d.title}>
+                                <Link href={d.href || ''} className="text-lg leading-7 text-gray-500 dark:text-gray-400 hover:text-gray-900 dark:hover:text-gray-100">
+                                    <p className="text-lg leading-7 text-blue-800 dark:text-gray-400 hover:text-gray-900 dark:hover:text-gray-100">
+                                        {d.title}
+                                    </p>
+                                </Link>
+                            </div>
+                        ))}
+                    </div>
+                </div>
+            </div >
+        </>
+    )
+}

--- a/app/work/page.tsx
+++ b/app/work/page.tsx
@@ -4,7 +4,7 @@ import { genPageMetadata } from 'app/seo'
 
 export const metadata = genPageMetadata({ title: 'Work' })
 
-export default function Projects() {
+export default function Work() {
   return (
     <>
       <div className="divide-y divide-gray-200 dark:divide-gray-700">
@@ -13,7 +13,7 @@ export default function Projects() {
             Work
           </h1>
           <p className="text-lg leading-7 text-gray-500 dark:text-gray-400">
-            Stuff I worked on that's now on the internet.
+            Stuff I worked on occupationally that's now on the internet.
             <br />
           </p>
         </div>

--- a/components/icons/ForkIcon.tsx
+++ b/components/icons/ForkIcon.tsx
@@ -1,0 +1,12 @@
+import { SVGProps } from 'react'
+
+const ForkIcon = (props: SVGProps<SVGSVGElement>) => {
+    const { width = 16, height = 16, ...rest } = props
+    return (
+        <svg xmlns="http://www.w3.org/2000/svg" viewBox={`0 0 ${width} ${height}`} {...rest}>
+            <path d="M5 5.372v.878c0 .414.336.75.75.75h4.5a.75.75 0 0 0 .75-.75v-.878a2.25 2.25 0 1 1 1.5 0v.878a2.25 2.25 0 0 1-2.25 2.25h-1.5v2.128a2.251 2.251 0 1 1-1.5 0V8.5h-1.5A2.25 2.25 0 0 1 3.5 6.25v-.878a2.25 2.25 0 1 1 1.5 0ZM5 3.25a.75.75 0 1 0-1.5 0 .75.75 0 0 0 1.5 0Zm6.75.75a.75.75 0 1 0 0-1.5.75.75 0 0 0 0 1.5Zm-3 8.75a.75.75 0 1 0-1.5 0 .75.75 0 0 0 1.5 0Z" />
+        </svg>
+    )
+}
+
+export default ForkIcon 

--- a/components/icons/index.tsx
+++ b/components/icons/index.tsx
@@ -1,0 +1,12 @@
+import { JSX, SVGProps } from 'react'
+
+const ForkIcon = (props: SVGProps<SVGSVGElement>): JSX.Element | undefined => {
+    const { width = 16, height = 16, ...rest } = props
+    return (
+        <svg xmlns="http://www.w3.org/2000/svg" viewBox={`0 0 ${width} ${height}`} {...rest} >
+            <path d="M5 5.372v.878c0 .414.336.75.75.75h4.5a.75.75 0 0 0 .75-.75v-.878a2.25 2.25 0 1 1 1.5 0v.878a2.25 2.25 0 0 1-2.25 2.25h-1.5v2.128a2.251 2.251 0 1 1-1.5 0V8.5h-1.5A2.25 2.25 0 0 1 3.5 6.25v-.878a2.25 2.25 0 1 1 1.5 0ZM5 3.25a.75.75 0 1 0-1.5 0 .75.75 0 0 0 1.5 0Zm6.75.75a.75.75 0 1 0 0-1.5.75.75 0 0 0 0 1.5Zm-3 8.75a.75.75 0 1 0-1.5 0 .75.75 0 0 0 1.5 0Z" />
+        </svg>
+    )
+}
+
+export default ForkIcon

--- a/data/headerNavLinks.ts
+++ b/data/headerNavLinks.ts
@@ -3,6 +3,7 @@ const headerNavLinks = [
   { href: '/blog', title: 'Blog' },
   { href: '/tags', title: 'Tags' },
   { href: '/work', title: 'Work' },
+  { href: '/projects', title: 'Projects' },
   { href: '/about', title: 'About' },
   { href: '/Chan_Jen_5.3.pdf', title: 'Resume' },
 ]

--- a/data/siteMetadata.js
+++ b/data/siteMetadata.js
@@ -16,7 +16,7 @@ const siteMetadata = {
   devto: 'https://dev.to/jenc',
   // facebook: 'https://facebook.com',
   // youtube: 'https://youtube.com',
-  linkedin: 'https://www.linkedin.com/in/jennifer7chan',
+  linkedin: 'https://www.linkedin.com/in/okjen',
   // threads: 'https://www.threads.net',
   // instagram: 'https://www.instagram.com',
   // medium: 'https://medium.com',

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "next": "15.2.3",
     "next-contentlayer2": "0.5.4",
     "next-themes": "^0.3.0",
-    "pliny": "0.4.1",
+    "pliny": "^0.4.1",
     "postcss": "^8.4.24",
     "react": "19.0.0",
     "react-dom": "19.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -11737,7 +11737,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"pliny@npm:0.4.1":
+"pliny@npm:^0.4.1":
   version: 0.4.1
   resolution: "pliny@npm:0.4.1"
   dependencies:
@@ -13825,7 +13825,7 @@ __metadata:
     next: 15.2.3
     next-contentlayer2: 0.5.4
     next-themes: ^0.3.0
-    pliny: 0.4.1
+    pliny: ^0.4.1
     postcss: ^8.4.24
     prettier: ^3.0.0
     prettier-plugin-tailwindcss: ^0.6.11


### PR DESCRIPTION
This pull request introduces a new "Projects" page that showcases open-source projects the user maintains or has contributed to, along with supporting updates across the codebase. The changes include the addition of new data structures for project metadata, a GitHub API integration to fetch project details, a new page implementation, a reusable `ForkIcon` component, and various minor updates to navigation and metadata.

### New "Projects" Page and Supporting Features:

* **`app/api/getGithubData.ts`:** Added `Project` type and two datasets (`ossData` and `contributionsData`) for maintaining and contributed projects. Implemented `getGithubData` function to fetch project details (e.g., stars, forks, watchers) from the GitHub API.

* **`app/projects/page.tsx`:** Created the "Projects" page to display open-source projects using `ossData` and `contributionsData`. Integrated `getGithubData` to fetch and display dynamic GitHub data, including stars, forks, and watchers.

### Reusable Component:

* **`components/icons/ForkIcon.tsx`:** Added a new `ForkIcon` component for displaying fork count on the "Projects" page.

### Navigation and Metadata Updates:

* **`data/headerNavLinks.ts`:** Added a "Projects" link to the header navigation.
* **`data/siteMetadata.js`:** Updated the LinkedIn URL in the site metadata.

### Minor Updates:

* **`app/work/page.tsx`:** Fixed the function name from `Projects` to `Work` and updated the description for clarity. [[1]](diffhunk://#diff-f89b9621cb683f74f4b728f6df4d7dcea855340d6f2a099e0180635ea1e063e3L7-R7) [[2]](diffhunk://#diff-f89b9621cb683f74f4b728f6df4d7dcea855340d6f2a099e0180635ea1e063e3L16-R16)
* **`package.json`:** Updated the `pliny` dependency version to use a caret (`^`) for more flexible versioning.