### PR TITLE
fix: worker deploy step

### DIFF
--- a/app/api/getDevToPublishedArticles.ts
+++ b/app/api/getDevToPublishedArticles.ts
@@ -22,10 +22,7 @@ const getDevToPublishedArticles = async () => {
   try {
     const res = await env.WORKER_SELF_REFERENCE?.fetch(endpoint, {
       headers: headers,
-      cache: 'force-cache',
-      next: {
-        revalidate: 3600 // stale after 1 hour
-      }
+      cache: 'force-cache'
     })
     if (res?.status !== 200) {
       console.error('🚨 Dev.to API error:', res?.status, res?.statusText)

--- a/app/api/getGithubData.ts
+++ b/app/api/getGithubData.ts
@@ -104,11 +104,8 @@ export default async function getGithubData(
           {
             headers: {
               Accept: 'application/vnd.github.v3+json',
-              Authorization: `Bearer ${process.env.GITHUB_TOKEN}`
-            },
-            next: {
-              revalidate: 3600, // cache for 1 hour
-              tags: ['github-data']
+              Authorization: `Bearer ${process.env.GITHUB_TOKEN}`,
+              cache: 'force-cache'
             }
           }
         )

--- a/app/api/getWebMentionsPerPost.ts
+++ b/app/api/getWebMentionsPerPost.ts
@@ -14,10 +14,7 @@ export default async function getWebMentionsPerPost(
   if (!cachedData) {
     const url = siteMetadata.siteUrl
     const res = await env.WORKER_SELF_REFERENCE?.fetch(
-      `https://webmention.io/api/mentions?per-page=200&target=${url}/blog/${post.slug}`,
-      {
-        next: { revalidate: 3600 * 24 } // revalidate once a day
-      }
+      `https://webmention.io/api/mentions?per-page=200&target=${url}/blog/${post.slug}`
     )
     if (!res?.ok) throw new Error('Failed to fetch')
     const data = await res?.json()

--- a/open-next.config.ts
+++ b/open-next.config.ts
@@ -1,6 +1,6 @@
 import { defineCloudflareConfig } from '@opennextjs/cloudflare'
-import r2IncrementalCache from '@opennextjs/cloudflare/overrides/incremental-cache/r2-incremental-cache'
+import stableIncrementalCache from '@opennextjs/cloudflare/overrides/incremental-cache/static-assets-incremental-cache'
 
 export default defineCloudflareConfig({
-  incrementalCache: r2IncrementalCache
+  incrementalCache: stableIncrementalCache
 })

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -26,7 +26,12 @@
   ],
   "env": {
     "preview": {
-      "NEXT_INC_CACHE_R2_BUCKET": "jen-preview-bucket"
+      "r2_buckets": [
+        {
+          "binding": "NEXT_INC_CACHE_R2_BUCKET",
+          "bucket_name": "jen-preview-bucket"
+        }
+      ]
     }
   }
 }


### PR DESCRIPTION
## Changes

This pull request focuses on simplifying caching strategies and improving stability in the application by removing revalidation configurations and switching to a more stable incremental cache implementation. Below are the most important changes grouped by theme.

### Caching strategy updates:
* [`app/api/getDevToPublishedArticles.ts`](diffhunk://#diff-7600adf651959a75f136f53afd04776030f725ffa434d12a849793ab6fa8a519L25-R25): Removed the `next.revalidate` configuration, simplifying the caching logic for fetching Dev.to articles.
* [`app/api/getGithubData.ts`](diffhunk://#diff-4092e980bf379a74b4a92dde110ab148374b6e3d17fbb404dbf5fd6d8a6f5eb1L107-R108): Removed the `next.revalidate` and `tags` configurations, while maintaining a `force-cache` strategy for GitHub API requests.
* [`app/api/getWebMentionsPerPost.ts`](diffhunk://#diff-29615a9083b31aab8bb5939755c5dd0c0b6ea04c0802bc446dddb96a47fff6b2L17-R17): Removed the `next.revalidate` configuration for web mentions, simplifying the caching behavior for these API calls.

### Incremental cache improvement:
* [`open-next.config.ts`](diffhunk://#diff-169baaf3d5915df036f1b26b1e83bb203ef33368e2bd82e4ba5d8da069ae6f85L2-R5): Replaced `r2IncrementalCache` with `stableIncrementalCache` to enhance the stability of the incremental caching mechanism.